### PR TITLE
Hotfix: Redundant foreign keys

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -97,11 +97,9 @@ CREATE TABLE "survey_questions" (
 
 
 ALTER TABLE "user_tags" ADD CONSTRAINT "user_tags_fk0" FOREIGN KEY ("user_id") REFERENCES "user"("id");
-ALTER TABLE "user_tags" ADD CONSTRAINT "user_tags_fk1" FOREIGN KEY ("tag_id") REFERENCES "tag"("id");
 ALTER TABLE "played" ADD CONSTRAINT "played_fk0" FOREIGN KEY ("user_id") REFERENCES "user"("id");
 ALTER TABLE "wishlist" ADD CONSTRAINT "wishlist_fk0" FOREIGN KEY ("user_id") REFERENCES "user"("id");
 ALTER TABLE "ignorelist" ADD CONSTRAINT "ignorelist_fk0" FOREIGN KEY ("user_id") REFERENCES "user"("id");
-ALTER TABLE "glossary" ADD CONSTRAINT "glossary_fk0" FOREIGN KEY ("tag_id") REFERENCES "tag"("id");
 
 -- Glossary Terms
 -- Add Tags


### PR DESCRIPTION
fix: deleted redundant "tag_id" foreign keys from glossary and user_tag database tables; updated database.sql