### PR TITLE
Move survey question caption to a "more info" button

### DIFF
--- a/src/components/SurveyOptions/SurveyOptions.jsx
+++ b/src/components/SurveyOptions/SurveyOptions.jsx
@@ -306,7 +306,7 @@ export default function SurveyOptions(props) {
     // pages 1-17 are slider questions
     // if page 18-20, show checkbox instead
     <>
-      {<h3>Value: {currentScore}</h3>}
+      {/*<h3>Value: {currentScore}</h3>*/}
       <section id="survey-select">
         {props.page < 16 ? (
           <Box sx={{ width: 'calc(100% - 150px)' }}>

--- a/src/components/SurveyPage/SurveyPage.css
+++ b/src/components/SurveyPage/SurveyPage.css
@@ -9,6 +9,13 @@
     width: 100%;
 }
 
+.more-info {
+    width: fit-content;
+    display: flex !important;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+}
 /*
 .survey-prev {
     display: flex;
@@ -30,8 +37,12 @@
     display: flex;
     flex-direction: column;
     justify-content: space-between;
+    text-align: center;
 }
 
-#survey-question {
-    height: 300px;
+#survey-body-question {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
 }

--- a/src/components/SurveyPage/SurveyPage.jsx
+++ b/src/components/SurveyPage/SurveyPage.jsx
@@ -1,39 +1,51 @@
-import { useState } from 'react'
+import React, { useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useSurveyData } from '../../hooks/storeHooks'
-import { Button } from '@mui/material'
 import { useEffect } from 'react'
 import SurveyOptions from '../SurveyOptions/SurveyOptions'
 import SurveyNextButton from '../SurveyNextButton/SurveyNextButton'
 import SurveyPrevButton from '../SurveyPrevButton/SurveyPrevButton'
-import SurveyIntro from "../SurveyIntro/SurveyIntro";
+import SurveyIntro from '../SurveyIntro/SurveyIntro'
 import './SurveyPage.css'
-import { useHistory } from 'react-router-dom'
-import { useParams } from 'react-router-dom'
+import { useHistory, useParams } from 'react-router-dom'
+import Dialog from '@mui/material/Dialog'
+import DialogContent from '@mui/material/DialogContent'
+import DialogContentText from '@mui/material/DialogContentText'
+import DialogTitle from '@mui/material/DialogTitle'
+import HelpIcon from '@mui/icons-material/Help';
 
 export default function SurveyPage() {
-  const surveyData = useSurveyData();
-  const dispatch = useDispatch();
-  console.log(surveyData);
-  const { id } = useParams();
-  const history = useHistory();
+  const surveyData = useSurveyData()
+  const dispatch = useDispatch()
+  console.log(surveyData)
+  const { id } = useParams()
+  const history = useHistory()
   const surveyQuestion = useSelector((store) => store.survey.surveyQuestions)
+  const [open, setOpen] = useState(false)
+
+  const handleClickOpen = () => {
+    setOpen(true)
+  }
+
+  const handleClose = () => {
+    setOpen(false)
+  }
 
   useEffect(() => {
-    dispatch({ type: 'SURVEY/FETCH' });
-}, []);
+    dispatch({ type: 'SURVEY/FETCH' })
+  }, [])
 
   const nextPage = () => {
     console.log('in nextpage')
     if (id < 17) {
-      history.push('/survey/' + (Number(id) + 1));
+      history.push('/survey/' + (Number(id) + 1))
     } else {
       dispatch({ type: 'SURVEY/POST_DATA', payload: surveyData })
     }
   }
 
   const prevPage = () => {
-    history.push('/survey/' + (Number(id) - 1));
+    history.push('/survey/' + (Number(id) - 1))
   }
 
   const nextBtnText = () => {
@@ -44,8 +56,29 @@ export default function SurveyPage() {
     <section id="survey-body">
       {Number(id) === 1 && <SurveyIntro />}
 
-      <h4>{surveyQuestion[Number(id) - 1]?.question}</h4>
-      <p>{surveyQuestion[Number(id) - 1]?.caption}</p>
+      <section id="survey-body-question">
+        <h4>
+          Question {id}: {surveyQuestion[Number(id) - 1]?.question}
+        </h4>
+        <div className="btn more-info" onClick={handleClickOpen}>
+          <HelpIcon />More Info
+        </div>
+      </section>
+      <Dialog
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="alert-dialog-title"
+        aria-describedby="alert-dialog-description"
+      >
+        <DialogTitle id="alert-dialog-title">
+          {surveyQuestion[Number(id) - 1]?.question}
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText id="alert-dialog-description">
+            {surveyQuestion[Number(id) - 1]?.caption}
+          </DialogContentText>
+        </DialogContent>
+      </Dialog>
       <SurveyOptions page={id} />
       <div className="survey-previous-next">
         {id > 1 && (

--- a/src/components/SurveyPage/SurveyPage.jsx
+++ b/src/components/SurveyPage/SurveyPage.jsx
@@ -60,9 +60,10 @@ export default function SurveyPage() {
         <h4>
           Question {id}: {surveyQuestion[Number(id) - 1]?.question}
         </h4>
+        {id < 16 &&
         <div className="btn more-info" onClick={handleClickOpen}>
           <HelpIcon />More Info
-        </div>
+        </div>}
       </section>
       <Dialog
         open={open}


### PR DESCRIPTION
Decluttering the survey question page by moving the caption to a "more info" button.
Clicking "more info" shows the caption.