### PR TITLE
RAWG logo now links to website

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -54,6 +54,6 @@ export default function Header() {
         ></path>
       </g>
     </svg>
-    <div id="rawg-credits">powered by <span id="rawg-logo">RAWG</span></div>
+    <div id="rawg-credits">powered by <a href="https://rawg.io/"><span id="rawg-logo">RAWG</span></a></div>
     </header>);
 }


### PR DESCRIPTION
RAWG requires that every page using their data has a hyperlink to their website. So I made the rawg header logo link to their website