### PR TITLE
make navbar equal width

### DIFF
--- a/src/components/ViewCollection/ViewCollection.css
+++ b/src/components/ViewCollection/ViewCollection.css
@@ -6,4 +6,5 @@
 
 .MuiTab-root {
     font-size: 18px;
+    width:calc(100% / 3);
 }


### PR DESCRIPTION
Change navbar css to make buttons equal width.
<img width="359" alt="Screen Shot 2023-02-13 at 8 47 11 AM" src="https://user-images.githubusercontent.com/7820165/218489662-aa1aa368-9e7e-4eec-8c32-dbebf74b476f.png">
